### PR TITLE
iteration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ test:
 	go test $(shell go list ./...)
 
 # Goファイルをフォーマット
-format:
+fmt:
 	go fmt ./...

--- a/iteration/repeat.go
+++ b/iteration/repeat.go
@@ -1,0 +1,9 @@
+package iteration
+
+func Repeat(character string, number int) string {
+	var repeated string
+	for i := 0; i < number; i++ {
+		repeated += character
+	}
+	return repeated
+}

--- a/iteration/repeat_test.go
+++ b/iteration/repeat_test.go
@@ -1,0 +1,27 @@
+package iteration
+
+import (
+	"fmt"
+	"testing"
+)
+
+func ExampleRepeat() {
+	repeated := Repeat("b", 3)
+	fmt.Println(repeated)
+	// Output: bbb
+}
+
+func TestRepeat(t *testing.T) {
+	repeated := Repeat("a", 5)
+	expected := "aaaaa"
+
+	if repeated != expected {
+		t.Errorf("expected %q but got %q", expected, repeated)
+	}
+}
+
+func BenchmarkRepeat(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Repeat("a", 5)
+	}
+}


### PR DESCRIPTION
やったこと
・iterationの実装とテスト
・フォーマットの修正コマンドを`make format`から`make fmt`に変更